### PR TITLE
Added Markdown help files to the project

### DIFF
--- a/Source/DSACL.psd1
+++ b/Source/DSACL.psd1
@@ -115,8 +115,7 @@ PrivateData = @{
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module
-# HelpInfoURI = ''
-
+ HelpInfoURI = 'https://github.com/ehmiiz/DSACL/blob/master/Source/en-US/DSACL-help.xml/'
 # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
 # DefaultCommandPrefix = ''
 

--- a/Source/Public/Set-DSACLOwner.ps1
+++ b/Source/Public/Set-DSACLOwner.ps1
@@ -1,12 +1,26 @@
+<#
+.SYNOPSIS
+    Sets an Active Directory object as the Owner of an Access Control List (ACL).
+
+.DESCRIPTION
+    The **Set-DSACLOwner** cmdlet will set the given OwnerDN (Objects Distinguished Name) as Owner of the specified TargetDN (Target Distinguished Name).
+    The TargetDN parameter specifies what object the modification will execute on.
+    The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.
+
+.EXAMPLE
+    Set-DSACLOwner -TargetDN "OU=Accounting,DC=FABRIKAM,DC=COM" -OwnerDN "CN=Chew David,OU=Accounting,DC=FABRIKAM,DC=COM"
+#>
 function Set-DSACLOwner {
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('chown')]
     [Alias('setowner')]
     param (
+        # DistinguishedName of object to modify ACL on.
         [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [String]
         $TargetDN,
 
+        # DistinguishedName of group or user to give permissions to.
         [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
         [String]
         $OwnerDN

--- a/Source/Public/Set-DSACLOwner.ps1
+++ b/Source/Public/Set-DSACLOwner.ps1
@@ -1,19 +1,12 @@
-<#
-.SYNOPSIS
-Set owner on any object in Active Directory
-
-#>
 function Set-DSACLOwner {
     [CmdletBinding(SupportsShouldProcess)]
     [Alias('chown')]
     [Alias('setowner')]
     param (
-        # DistinguishedName of object to modify ACL on.
         [Parameter(Mandatory,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [String]
         $TargetDN,
 
-        # DistinguishedName of group or user to give permissions to.
         [Parameter(Mandatory,ValueFromPipelineByPropertyName)]
         [String]
         $OwnerDN

--- a/Source/build.psd1
+++ b/Source/build.psd1
@@ -2,7 +2,7 @@
     Path = "DSACL.psd1"
     OutputDirectory = "..\bin\DSACL"
     Prefix = '.\_ModuleVariables.ps1'
-    SourceDirectories = 'Classes','Private','Public'
+    SourceDirectories = 'Classes','Private','Public','en-US'
     PublicFilter = 'Public\*.ps1'
     VersionedOutputDirectory = $true
 }

--- a/Source/en-US/DSACL-help.xml
+++ b/Source/en-US/DSACL-help.xml
@@ -6,11 +6,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLCreateChild</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate rights to create objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate rights to create objects of selected type in target (usually an Organizational Unit)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -18,7 +18,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -34,7 +34,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName to delegate to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -46,7 +46,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Switch parameter that disables Inheritance when delegating</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -57,7 +57,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid is used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -69,7 +69,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on, usually an OU</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -84,7 +84,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -100,7 +100,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName to delegate to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -112,7 +112,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Switch parameter that disables Inheritance when delegating</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -123,7 +123,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -144,7 +144,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on, usually an OU</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -159,7 +159,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -171,7 +171,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName to delegate to</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -183,7 +183,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Switch parameter that disables Inheritance when delegating</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -195,7 +195,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid is used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -207,7 +207,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -219,7 +219,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on, usually an OU</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -257,9 +257,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLCreateChild -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup access to create user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -271,11 +271,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLCustom</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate custom rights in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Used to delegate any custom rights in Active Directory. Requires knowledge of creating ActiveDirectoryAccessRules, please use with caution.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -283,7 +283,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -299,7 +299,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -332,7 +332,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -344,7 +344,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -363,7 +363,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -375,7 +375,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -387,7 +387,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -402,7 +402,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -418,7 +418,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -451,7 +451,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -470,7 +470,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -482,7 +482,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -494,7 +494,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SID</maml:name>
           <maml:description>
-            <maml:para>{{ Fill SID Description }}</maml:para>
+            <maml:para>Specify Secure Identifier (SID)</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -506,7 +506,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -521,7 +521,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -537,7 +537,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -570,7 +570,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -589,7 +589,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -601,7 +601,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -613,7 +613,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Self</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Self Description }}</maml:para>
+            <maml:para>Give access to "Self" instead of a user or group</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -624,7 +624,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -639,7 +639,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessControlType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -651,7 +651,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ActiveDirectoryRights</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          <maml:para>List of access rights that should be applied</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
         <dev:type>
@@ -663,7 +663,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -675,7 +675,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>InheritanceType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          <maml:para>Sets if and how this rule should be inherited</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
         <dev:type>
@@ -687,7 +687,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>InheritedObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          <maml:para>Sets guid of object types that should inherit this rule</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -699,7 +699,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          <maml:para>Sets guid where access right should apply</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -711,7 +711,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>SID</maml:name>
         <maml:description>
-          <maml:para>{{ Fill SID Description }}</maml:para>
+          <maml:para>Specify Secure Identifier (SID)</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -723,7 +723,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Self</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Self Description }}</maml:para>
+          <maml:para>Give access to "Self" instead of a user or group</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -735,7 +735,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -787,11 +787,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLDeleteChild</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate rights to delete objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate rights to delete objects of selected type in target (usually an OU)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -799,7 +799,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -815,7 +815,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -827,7 +827,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>IncludeChildren</maml:name>
           <maml:description>
-            <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+            <maml:para>Adds DeleteTree right allowing to delete an object and all its child objects in one operation</maml:para>
+            <maml:para>This is often required for deleting computer objects</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -838,7 +839,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -849,7 +850,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -861,7 +862,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -876,7 +877,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -892,7 +893,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -904,7 +905,8 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>IncludeChildren</maml:name>
           <maml:description>
-            <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+            <maml:para>Adds DeleteTree right allowing to delete an object and all its child objects in one operation</maml:para>
+            <maml:para>This is often required for deleting computer objects</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -915,7 +917,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -926,7 +928,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -947,7 +949,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -962,7 +964,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -974,7 +976,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -986,7 +988,8 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>IncludeChildren</maml:name>
         <maml:description>
-          <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+          <maml:para>Adds DeleteTree right allowing to delete an object and all its child objects in one operation</maml:para>
+          <maml:para>This is often required for deleting computer objects</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -998,7 +1001,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1010,7 +1013,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -1022,7 +1025,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1034,7 +1037,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1072,9 +1075,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLDeleteChild -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup access to delete user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1086,11 +1089,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLFullControl</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate FullControl rights on objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate FullControl rights on objects of selected type in target (usually an OU)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1098,7 +1101,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -1114,7 +1117,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1126,7 +1129,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1137,7 +1140,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -1149,7 +1152,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1164,7 +1167,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -1180,7 +1183,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1192,7 +1195,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1203,7 +1206,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -1224,7 +1227,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1239,7 +1242,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Specifies if the Access Control Entry is Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -1251,7 +1254,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1263,7 +1266,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1275,7 +1278,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -1287,7 +1290,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1299,7 +1302,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1337,9 +1340,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLFullControl -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup FullControl of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1351,11 +1354,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLJoinDomain</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give DelegateDN rights to join computers in target (usually an OU).</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give DelegateDN rights to join computers in target (usually an OU).</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1363,7 +1366,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1375,7 +1378,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1387,7 +1390,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AllowCreate</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AllowCreate Description }}</maml:para>
+            <maml:para>Allow creating computer objects, this allows to join computers without a pre-staged computer account</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1398,7 +1401,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1412,7 +1415,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AllowCreate</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AllowCreate Description }}</maml:para>
+          <maml:para>Allow creating computer objects, this allows to join computers without a pre-staged computer account</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1424,7 +1427,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1436,7 +1439,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1448,7 +1451,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1486,9 +1489,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLJoinDomain -TargetDN $ComputersOU -DelegateDN $JoinDomainAccounts -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $JoinDomainAccounts rights to join computers to the domain. Requires a computer account to be created already.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1500,11 +1503,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLLinkGPO</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegate rights to link GPO on target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Delegate rights to link GPO on target (usually an OU)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1512,7 +1515,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1524,7 +1527,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1536,7 +1539,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -1552,7 +1555,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1566,7 +1569,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -1578,7 +1581,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1590,7 +1593,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1602,7 +1605,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1640,9 +1643,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLLinkGPO -TargetDN $UsersOU -DelegateDN $GPAdmin -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $GPAdmin rights to link GPOs on the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1654,11 +1657,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLManageGroupMember</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate rights to manage members in group(s).</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate rights to manage members in group(s).</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1666,7 +1669,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -1682,7 +1685,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1694,7 +1697,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>DirectOnGroup</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DirectOnGroup Description }}</maml:para>
+            <maml:para>Sets access right to "This object only", use this when TargetDN is a group.</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1705,7 +1708,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1720,7 +1723,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -1736,7 +1739,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1748,7 +1751,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "Children". Use this to effect all groups in OU but not subOUs</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -1759,7 +1762,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1774,7 +1777,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -1786,7 +1789,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1798,7 +1801,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>DirectOnGroup</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DirectOnGroup Description }}</maml:para>
+          <maml:para>Sets access right to "This object only", use this when TargetDN is a group.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1810,7 +1813,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "Children". Use this to effect all groups in OU but not subOUs</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1822,7 +1825,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1860,9 +1863,23 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLManageGroupMember -TargetDN $GroupsOU -DelegateDN $AccessAdminGroup -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of any group in the OU with DistinguishedName in $GroupsOU and all sub-OUs. Add -NoInheritance do disable inheritance.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 2 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Add-DSACLManageGroupMember -TargetDN $GroupsOU -DelegateDN $AccessAdminGroup -AccessType Allow -NoInheritance</dev:code>
+        <dev:remarks>
+          <maml:para>Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of any group in the OU with DistinguishedName in $GroupsOU. Will not effect groups in sub-OUs.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>-------------------------- Example 3 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Add-DSACLManageGroupMember -TargetDN $SpecialGroup -DelegateDN $AccessAdminGroup -AccessType Allow -DirectOnGroup</dev:code>
+        <dev:remarks>
+          <maml:para>Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of the group in with DistinguishedName in $SpecialGroup.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1874,11 +1891,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLManagerCanUpdateGroupMember</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate rights to groups manager to manage members in group(s). Note that this access stays with the user if the manager changes.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate rights to groups manager to manage members in group(s). Note that this access stays with the user if the manager changes.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1886,7 +1903,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Has to be a group.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1901,7 +1918,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Has to be a group.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1939,9 +1956,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLManagerCanUpdateGroupMember -TargetDN $Group</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the current manager of the group in $Group access to manage members. Note that this access stays with the user if the manager changes.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -1953,11 +1970,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLMoveObjectFrom</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegates right to move object of type ObjectTypeName from TargetDN. Moving also requires create-child rights in target container.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Delegates the rights to rename and delete objects in TargetDN.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -1965,7 +1982,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to allow being moved</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -1986,7 +2003,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
           <dev:type>
@@ -1998,7 +2015,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
           <dev:type>
@@ -2010,7 +2027,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2024,7 +2041,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
         <dev:type>
@@ -2036,7 +2053,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2048,7 +2065,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to allow being moved</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2060,7 +2077,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
         <dev:type>
@@ -2112,7 +2129,7 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLRenameObject</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate rights to rename objects in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -2124,7 +2141,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2136,7 +2153,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2147,7 +2164,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to allow being renamed</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -2168,7 +2185,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2183,7 +2200,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2195,7 +2212,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2207,7 +2224,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to allow being renamed</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2219,7 +2236,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2257,9 +2274,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLRenameObject -ObjectTypeName Computer -TargetDN $ComputersOU -DelegateDN $ComputerAdminGroup -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $ComputerAdminGroup rights to rename computers in the OU with DistinguishedName in $ComputersOU and all sub-OUs. Add -NoInheritance do disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -2271,11 +2288,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLReplicatingDirectoryChanges</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Give Delegate "Replicating Directory Changes" rights on domain with DistinguishedName in target</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Give Delegate "Replicating Directory Changes" rights on domain with DistinguishedName in target</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -2283,7 +2300,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2295,7 +2312,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AllowReplicateSecrets</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AllowReplicateSecrets Description }}</maml:para>
+            <maml:para>Allow replicating secrets, like passwords (Corresponds to "Replicating Directory Changes All")</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2309,7 +2326,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AllowReplicateSecrets</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AllowReplicateSecrets Description }}</maml:para>
+          <maml:para>Allow replicating secrets, like passwords (Corresponds to "Replicating Directory Changes All")</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2321,7 +2338,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2359,9 +2376,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLReplicatingDirectoryChanges -DelegateDN $AADCServiceAccount</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the service account with DistinguishedName in $AADCServiceAccount the right "Replicating Directory Changes". Add -AllowReplicateSecrets to grant "Replicating Directory Changes All" instead..</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -2373,11 +2390,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLResetPassword</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegate ResetPassword rights on objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Delegate ResetPassword rights on objects of selected type in target (usually an OU)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -2385,7 +2402,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -2401,7 +2418,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2413,7 +2430,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2424,7 +2441,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -2436,7 +2453,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2451,7 +2468,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -2467,7 +2484,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2479,7 +2496,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2490,7 +2507,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
@@ -2508,7 +2525,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2523,7 +2540,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -2535,7 +2552,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2547,7 +2564,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2559,7 +2576,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -2571,7 +2588,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2583,7 +2600,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2621,9 +2638,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLResetPassword -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup ResetPassword rights of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -2635,11 +2652,11 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLWriteAccountRestrictions</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegate rights to write to the property set "Account Restrictions" on objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Delegate rights to write to the property set "Account Restrictions" on objects of selected type in target (usually an OU)</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -2647,7 +2664,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>llow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -2663,7 +2680,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2675,7 +2692,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2686,7 +2703,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -2698,7 +2715,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2713,7 +2730,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>llow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -2729,7 +2746,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2741,7 +2758,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2752,7 +2769,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
@@ -2770,7 +2787,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2785,7 +2802,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>llow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -2797,7 +2814,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2809,7 +2826,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -2821,7 +2838,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -2833,7 +2850,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2845,7 +2862,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -2883,9 +2900,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLWriteAccountRestrictions -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup rights to SET SPN of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -2897,7 +2914,7 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLWriteDNSHostName</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegate rights to SET DNSHostName on objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -2909,7 +2926,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny. Allow is set by default</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -2925,7 +2942,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2937,7 +2954,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2948,7 +2965,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -2960,7 +2977,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -2972,7 +2989,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ValidatedOnly</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+            <maml:para>Only effects validated writes</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -2986,7 +3003,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny. Allow is set by default</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -3002,7 +3019,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3014,7 +3031,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3025,7 +3042,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
@@ -3042,7 +3059,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3054,7 +3071,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ValidatedOnly</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+            <maml:para>Only effects validated writes</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3068,7 +3085,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Allow or Deny. Allow is set by default</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -3080,7 +3097,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3092,7 +3109,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3104,7 +3121,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -3116,7 +3133,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3128,7 +3145,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3140,7 +3157,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ValidatedOnly</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          <maml:para>Only effects validated writes</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3178,9 +3195,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLWriteDNSHostName -TargetDN $ComputersOU -DelegateDN $ComputerAdminGroup -ObjectTypeName Computer -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $ComputerAdminGroup rights to SET DNSHostName of computer objects in the OU with DistinguishedName in $ComputersOU and all sub-OUs. Add -NoInheritance to disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -3192,7 +3209,7 @@
       <command:verb>Add</command:verb>
       <command:noun>DSACLWriteServicePrincipalName</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Delegate rights to SET ServicePrincipalName (SPN) on objects of selected type in target (usually an OU)</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
@@ -3204,7 +3221,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -3220,7 +3237,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3232,7 +3249,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3243,7 +3260,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeGuid</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+            <maml:para>ObjectType guid, used for custom object types</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -3255,7 +3272,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3267,7 +3284,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ValidatedOnly</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+            <maml:para>Only effects validated writes</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3281,7 +3298,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>AccessType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessType Description }}</maml:para>
+            <maml:para>Allow or Deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -3297,7 +3314,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>DelegateDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+            <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3309,7 +3326,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoInheritance</maml:name>
           <maml:description>
-            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+            <maml:para>Sets access right to "This object only"</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3320,7 +3337,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ObjectTypeName</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+            <maml:para>Object type to give full control over</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
@@ -3338,7 +3355,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>TargetDN</maml:name>
           <maml:description>
-            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+            <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3350,7 +3367,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ValidatedOnly</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+            <maml:para>Only effects validated writes</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -3364,7 +3381,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>AccessType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessType Description }}</maml:para>
+          <maml:para>Allow or Deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -3376,7 +3393,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>DelegateDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          <maml:para>DistinguishedName of group or user to give permissions to.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3388,7 +3405,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoInheritance</maml:name>
         <maml:description>
-          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          <maml:para>Sets access right to "This object only"</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3400,7 +3417,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeGuid</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          <maml:para>ObjectType guid, used for custom object types</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -3412,7 +3429,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ObjectTypeName</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          <maml:para>Object type to give full control over</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3424,7 +3441,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>TargetDN</maml:name>
         <maml:description>
-          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          <maml:para>DistinguishedName of object to modify ACL on. Usually an OU.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3436,7 +3453,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>ValidatedOnly</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          <maml:para>Only effects validated writes</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -3474,9 +3491,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; Add-DSACLWriteServicePrincipalName -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Will give the group with DistinguishedName in $UserAdminGroup rights to SET SPN of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -3877,11 +3894,11 @@
       <command:verb>New</command:verb>
       <command:noun>DSACLAccessRule</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Create Access Control Entry for Active Directory ACL</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Create Access Control Entry for Active Directory ACL</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -3889,7 +3906,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -3905,7 +3922,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -3938,7 +3955,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -3950,7 +3967,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -3969,7 +3986,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -3981,7 +3998,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -3996,7 +4013,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -4012,7 +4029,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4045,7 +4062,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4057,7 +4074,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4076,7 +4093,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4091,7 +4108,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -4107,7 +4124,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4140,7 +4157,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4152,7 +4169,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4171,7 +4188,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4186,7 +4203,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -4202,7 +4219,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4235,7 +4252,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4247,7 +4264,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4269,7 +4286,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AccessControlType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
@@ -4285,7 +4302,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4318,7 +4335,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4330,7 +4347,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4345,7 +4362,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>AccessControlType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          <maml:para>Sets allow or deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
         <dev:type>
@@ -4357,7 +4374,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ActiveDirectoryRights</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          <maml:para>List of access rights that should be applied</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
         <dev:type>
@@ -4369,7 +4386,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>Identity</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Identity Description }}</maml:para>
+          <maml:para>SID of principal that will rule will apply to</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
         <dev:type>
@@ -4381,7 +4398,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>InheritanceType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          <maml:para>Sets if and how this rule should be inherited</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
         <dev:type>
@@ -4393,7 +4410,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>InheritedObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          <maml:para>Sets guid of object types that should inherit this rule</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -4405,7 +4422,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          <maml:para>Sets guid where access right should apply</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -4475,9 +4492,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; New-ADAccessRule -Identity $SID -ActiveDirectoryRights 'CreateChild', 'DeleteChild' -AccessControlType Allow -ObjectType $TypeGuid -InheritanceType None</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Create access rule that gives the object with SID $SID access to create and delete objects of type $TypeGuid on "this object only"</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>
@@ -4489,11 +4506,11 @@
       <command:verb>New</command:verb>
       <command:noun>DSACLAuditRule</command:noun>
       <maml:description>
-        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+        <maml:para>Create Access Control Entry for Active Directory ACL</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>{{ Fill in the Description }}</maml:para>
+      <maml:para>Create Access Control Entry for Active Directory ACL</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -4501,7 +4518,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4534,7 +4551,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AuditFlags</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4551,7 +4568,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4563,7 +4580,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4582,7 +4599,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4594,7 +4611,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4609,7 +4626,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4642,7 +4659,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AuditFlags</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4659,7 +4676,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4671,7 +4688,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4690,7 +4707,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4705,7 +4722,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4738,7 +4755,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AuditFlags</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4755,7 +4772,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4767,7 +4784,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4786,7 +4803,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritedObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+            <maml:para>Sets guid of object types that should inherit this rule</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4801,7 +4818,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4834,7 +4851,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AuditFlags</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4851,7 +4868,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4863,7 +4880,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>InheritanceType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+            <maml:para>Sets if and how this rule should be inherited</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4885,7 +4902,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ActiveDirectoryRights</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+            <maml:para>List of access rights that should be applied</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
@@ -4918,7 +4935,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>AuditFlags</maml:name>
           <maml:description>
-            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+            <maml:para>Sets allow or deny</maml:para>
           </maml:description>
           <command:parameterValueGroup>
             <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
@@ -4935,7 +4952,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
           <maml:name>Identity</maml:name>
           <maml:description>
-            <maml:para>{{ Fill Identity Description }}</maml:para>
+            <maml:para>SID of principal that will rule will apply to</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
           <dev:type>
@@ -4947,7 +4964,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
           <maml:name>ObjectType</maml:name>
           <maml:description>
-            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+            <maml:para>Sets guid where access right should apply</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
           <dev:type>
@@ -4962,7 +4979,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ActiveDirectoryRights</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          <maml:para>List of access rights that should be applied</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
         <dev:type>
@@ -4974,7 +4991,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>AuditFlags</maml:name>
         <maml:description>
-          <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          <maml:para>Sets allow or deny</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
         <dev:type>
@@ -4986,7 +5003,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
         <maml:name>Identity</maml:name>
         <maml:description>
-          <maml:para>{{ Fill Identity Description }}</maml:para>
+          <maml:para>SID of principal that will rule will apply to</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
         <dev:type>
@@ -4998,7 +5015,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>InheritanceType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          <maml:para>Sets if and how this rule should be inherited</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
         <dev:type>
@@ -5010,7 +5027,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>InheritedObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          <maml:para>Sets guid of object types that should inherit this rule</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -5022,7 +5039,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
         <maml:name>ObjectType</maml:name>
         <maml:description>
-          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          <maml:para>Sets guid where access right should apply</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
         <dev:type>
@@ -5092,9 +5109,9 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:code>PS C:\&gt; New-ADAccessRule -Identity $SID -ActiveDirectoryRights 'CreateChild', 'DeleteChild' -AccessControlType Allow -ObjectType $TypeGuid -InheritanceType None</dev:code>
         <dev:remarks>
-          <maml:para>{{ Add example description here }}</maml:para>
+          <maml:para>Create access rule that gives the object with SID $SID access to create and delete objects of type $TypeGuid on "this object only"</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/Source/en-US/DSACL-help.xml
+++ b/Source/en-US/DSACL-help.xml
@@ -1,0 +1,5701 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLCreateChild</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLCreateChild</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLCreateChild</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLCreateChild</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Contact</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLCustom</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLCustom</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLCustom</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLCustom</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>SID</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill SID Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLCustom</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Self</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Self Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessControlType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ActiveDirectoryRights</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryRights[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>InheritanceType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>InheritedObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>SID</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill SID Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Self</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Self Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLDeleteChild</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLDeleteChild</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLDeleteChild</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>IncludeChildren</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLDeleteChild</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>IncludeChildren</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Contact</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>IncludeChildren</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill IncludeChildren Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLFullControl</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLFullControl</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLFullControl</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLFullControl</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Contact</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLJoinDomain</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLJoinDomain</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLJoinDomain</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AllowCreate</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AllowCreate Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AllowCreate</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AllowCreate Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLLinkGPO</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLLinkGPO</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLLinkGPO</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLManageGroupMember</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLManageGroupMember</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLManageGroupMember</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DirectOnGroup</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DirectOnGroup Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLManageGroupMember</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DirectOnGroup</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DirectOnGroup Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLManagerCanUpdateGroupMember</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLManagerCanUpdateGroupMember</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLManagerCanUpdateGroupMember</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLMoveObjectFrom</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLMoveObjectFrom</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLMoveObjectFrom</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Contact</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLRenameObject</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLRenameObject</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLRenameObject</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Contact</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Group</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLReplicatingDirectoryChanges</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLReplicatingDirectoryChanges</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLReplicatingDirectoryChanges</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AllowReplicateSecrets</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AllowReplicateSecrets Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AllowReplicateSecrets</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AllowReplicateSecrets Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLResetPassword</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLResetPassword</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLResetPassword</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLResetPassword</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLWriteAccountRestrictions</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLWriteAccountRestrictions</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteAccountRestrictions</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteAccountRestrictions</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLWriteDNSHostName</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLWriteDNSHostName</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteDNSHostName</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ValidatedOnly</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteDNSHostName</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ValidatedOnly</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ValidatedOnly</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Add-DSACLWriteServicePrincipalName</command:name>
+      <command:verb>Add</command:verb>
+      <command:noun>DSACLWriteServicePrincipalName</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteServicePrincipalName</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeGuid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ValidatedOnly</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>Add-DSACLWriteServicePrincipalName</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>AccessType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>DelegateDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoInheritance</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ObjectTypeName</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">User</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Computer</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ManagedServiceAccount</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GroupManagedServiceAccount</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill TargetDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ValidatedOnly</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>AccessType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>DelegateDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DelegateDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoInheritance</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NoInheritance Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeGuid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeGuid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ObjectTypeName</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectTypeName Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill TargetDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ValidatedOnly</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ValidatedOnly Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>ConvertFrom-DSACLInheritedObjectTypeGuid</command:name>
+      <command:verb>ConvertFrom</command:verb>
+      <command:noun>DSACLInheritedObjectTypeGuid</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>ConvertFrom-DSACLInheritedObjectTypeGuid</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Access, ACE">
+          <maml:name>AccessRule</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessRule Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryAccessRule</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryAccessRule</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>ConvertFrom-DSACLInheritedObjectTypeGuid</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Audit">
+          <maml:name>AuditRule</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditRule Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryAuditRule</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryAuditRule</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Access, ACE">
+        <maml:name>AccessRule</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessRule Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryAccessRule</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryAccessRule</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Audit">
+        <maml:name>AuditRule</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AuditRule Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryAuditRule</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryAuditRule</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryAccessRule</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryAuditRule</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>ConvertFrom-DSACLObjectTypeGuid</command:name>
+      <command:verb>ConvertFrom</command:verb>
+      <command:noun>DSACLObjectTypeGuid</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>ConvertFrom-DSACLObjectTypeGuid</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Access, ACE">
+          <maml:name>AccessRule</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessRule Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryAccessRule</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryAccessRule</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>ConvertFrom-DSACLObjectTypeGuid</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Audit">
+          <maml:name>AuditRule</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditRule Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryAuditRule</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryAuditRule</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Access, ACE">
+        <maml:name>AccessRule</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessRule Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryAccessRule</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryAccessRule</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="Audit">
+        <maml:name>AuditRule</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AuditRule Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryAuditRule</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryAuditRule</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryAccessRule</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryAuditRule</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-DSACLDefaultContainer</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DSACLDefaultContainer</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-DSACLDefaultContainer</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>DomainDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DomainDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Type Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Users</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Computers</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DomainDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Type Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Get-DSACLMachineAccountQuota</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DSACLMachineAccountQuota</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-DSACLMachineAccountQuota</maml:name>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters />
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-DSACLAccessRule</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DSACLAccessRule</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAccessRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAccessRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAccessRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAccessRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAccessRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AccessControlType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Allow</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Deny</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+          <dev:type>
+            <maml:name>AccessControlType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>AccessControlType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AccessControlType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AccessControlType</command:parameterValue>
+        <dev:type>
+          <maml:name>AccessControlType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ActiveDirectoryRights</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryRights[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>Identity</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Identity Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+        <dev:type>
+          <maml:name>SecurityIdentifier</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>InheritanceType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>InheritedObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Security.Principal.SecurityIdentifier</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryRights[]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Security.AccessControl.AccessControlType</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Guid</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectorySecurityInheritance</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>New-DSACLAuditRule</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DSACLAuditRule</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAuditRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AuditFlags</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Success</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Failure</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+          <dev:type>
+            <maml:name>AuditFlags</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAuditRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AuditFlags</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Success</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Failure</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+          <dev:type>
+            <maml:name>AuditFlags</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAuditRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AuditFlags</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Success</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Failure</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+          <dev:type>
+            <maml:name>AuditFlags</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritedObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAuditRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AuditFlags</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Success</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Failure</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+          <dev:type>
+            <maml:name>AuditFlags</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>InheritanceType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">All</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Descendents</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">SelfAndChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Children</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem>
+        <maml:name>New-DSACLAuditRule</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ActiveDirectoryRights</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">CreateChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteChild</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListChildren</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Self</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteProperty</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">DeleteTree</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ListObject</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ExtendedRight</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">ReadControl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericExecute</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericWrite</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericRead</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteDacl</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">WriteOwner</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">GenericAll</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Synchronize</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">AccessSystemSecurity</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+          <dev:type>
+            <maml:name>ActiveDirectoryRights[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>AuditFlags</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Success</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Failure</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+          <dev:type>
+            <maml:name>AuditFlags</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+          <maml:name>Identity</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Identity Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+          <dev:type>
+            <maml:name>SecurityIdentifier</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+          <maml:name>ObjectType</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill ObjectType Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ActiveDirectoryRights</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ActiveDirectoryRights Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectoryRights[]</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectoryRights[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>AuditFlags</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill AuditFlags Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">AuditFlags</command:parameterValue>
+        <dev:type>
+          <maml:name>AuditFlags</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="none">
+        <maml:name>Identity</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Identity Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecurityIdentifier</command:parameterValue>
+        <dev:type>
+          <maml:name>SecurityIdentifier</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>InheritanceType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritanceType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ActiveDirectorySecurityInheritance</command:parameterValue>
+        <dev:type>
+          <maml:name>ActiveDirectorySecurityInheritance</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>InheritedObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill InheritedObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="none">
+        <maml:name>ObjectType</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill ObjectType Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Security.Principal.SecurityIdentifier</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectoryRights[]</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Security.AccessControl.AuditFlags</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Guid</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.DirectoryServices.ActiveDirectorySecurityInheritance</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Register-DSACLRightsMapVariable</command:name>
+      <command:verb>Register</command:verb>
+      <command:noun>DSACLRightsMapVariable</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Register-DSACLRightsMapVariable</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Scope</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Scope Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Scope</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Scope Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Resolve-DSACLGuid</command:name>
+      <command:verb>Resolve</command:verb>
+      <command:noun>DSACLGuid</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Resolve-DSACLGuid</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Guid</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Guid Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Guid</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Guid Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Resolve-DSACLObjectName</command:name>
+      <command:verb>Resolve</command:verb>
+      <command:noun>DSACLObjectName</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Resolve-DSACLObjectName</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Name Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Name Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-DSACLDefaultContainer</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>DSACLDefaultContainer</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-DSACLDefaultContainer</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>DomainDN</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill DomainDN Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Type Description }}</maml:para>
+          </maml:description>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" command:variableLength="false">Users</command:parameterValue>
+            <command:parameterValue required="false" command:variableLength="false">Computers</command:parameterValue>
+          </command:parameterValueGroup>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+          <maml:name>NewValue</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill NewValue Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>DomainDN</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill DomainDN Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="2" aliases="none">
+        <maml:name>NewValue</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill NewValue Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="none">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Type Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-DSACLMachineAccountQuota</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>DSACLMachineAccountQuota</command:noun>
+      <maml:description>
+        <maml:para>{{ Fill in the Synopsis }}</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>{{ Fill in the Description }}</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-DSACLMachineAccountQuota</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Quota</maml:name>
+          <maml:description>
+            <maml:para>{{ Fill Quota Description }}</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Quota</maml:name>
+        <maml:description>
+          <maml:para>{{ Fill Quota Description }}</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; {{ Add example code here }}</dev:code>
+        <dev:remarks>
+          <maml:para>{{ Add example description here }}</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
+      <command:name>Set-DSACLOwner</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>DSACLOwner</command:noun>
+      <maml:description>
+        <maml:para>Sets an Active Directory object as the Owner of an Access Control List (ACL).</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>The Set-DSACLOwner cmdlet will set the given OwnerDN (Objects Distinguished Name) as Owner of the specified TargetDN (Target Distinguished Name).</maml:para>
+      <maml:para>The TargetDN parameter specifies what object the modification will execute on.</maml:para>
+      <maml:para>The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-DSACLOwner</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+          <maml:name>TargetDN</maml:name>
+          <maml:description>
+            <maml:para>The TargetDN parameter specifies what object the modification will execute on.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>OwnerDN</maml:name>
+          <maml:description>
+            <maml:para>The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+          <maml:name>Confirm</maml:name>
+          <maml:description>
+            <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+          <maml:name>WhatIf</maml:name>
+          <maml:description>
+            <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="cf">
+        <maml:name>Confirm</maml:name>
+        <maml:description>
+          <maml:para>Prompts you for confirmation before running the cmdlet.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>OwnerDN</maml:name>
+        <maml:description>
+          <maml:para>The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="0" aliases="none">
+        <maml:name>TargetDN</maml:name>
+        <maml:description>
+          <maml:para>The TargetDN parameter specifies what object the modification will execute on.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="wi">
+        <maml:name>WhatIf</maml:name>
+        <maml:description>
+          <maml:para>Shows what would happen if the cmdlet runs. The cmdlet is not run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- Example 1 --------------------------</maml:title>
+        <dev:code>PS C:\&gt; Set-DSACLOwner -TargetDN "OU=Accounting,DC=FABRIKAM,DC=COM" -OwnerDN "CN=Chew David,OU=Accounting,DC=FABRIKAM,DC=COM"</dev:code>
+        <dev:remarks>
+          <maml:para>The following example will set Chew David as owner of the Accounting Organizational Units Access Control List.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>

--- a/docs/Add-DSACLCreateChild.md
+++ b/docs/Add-DSACLCreateChild.md
@@ -1,0 +1,145 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLCreateChild
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLCreateChild -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLCreateChild -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: Computer, Contact, Group, ManagedServiceAccount, GroupManagedServiceAccount, User, All
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLCreateChild.md
+++ b/docs/Add-DSACLCreateChild.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLCreateChild
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate rights to create objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -25,21 +25,22 @@ Add-DSACLCreateChild -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Gu
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate rights to create objects of selected type in target (usually an Organizational Unit)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLCreateChild -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup access to create user objects in
+the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Specifies if the Access Control Entry is Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +56,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName to delegate to
 
 ```yaml
 Type: String
@@ -70,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Switch parameter that disables Inheritance when delegating
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid is used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on, usually an OU
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLCustom.md
+++ b/docs/Add-DSACLCustom.md
@@ -1,0 +1,200 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLCustom
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### Delegate (Default)
+```
+Add-DSACLCustom -TargetDN <String> -DelegateDN <String> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> [-ObjectType <Guid>]
+ [-InheritanceType <ActiveDirectorySecurityInheritance>] [-InheritedObjectType <Guid>] [<CommonParameters>]
+```
+
+### Sid
+```
+Add-DSACLCustom -TargetDN <String> -SID <String> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> [-ObjectType <Guid>]
+ [-InheritanceType <ActiveDirectorySecurityInheritance>] [-InheritedObjectType <Guid>] [<CommonParameters>]
+```
+
+### Self
+```
+Add-DSACLCustom -TargetDN <String> [-Self] -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> [-ObjectType <Guid>]
+ [-InheritanceType <ActiveDirectorySecurityInheritance>] [-InheritedObjectType <Guid>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessControlType
+{{ Fill AccessControlType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ActiveDirectoryRights
+{{ Fill ActiveDirectoryRights Description }}
+
+```yaml
+Type: ActiveDirectoryRights[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: CreateChild, DeleteChild, ListChildren, Self, ReadProperty, WriteProperty, DeleteTree, ListObject, ExtendedRight, Delete, ReadControl, GenericExecute, GenericWrite, GenericRead, WriteDacl, WriteOwner, GenericAll, Synchronize, AccessSystemSecurity
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: Delegate
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InheritanceType
+{{ Fill InheritanceType Description }}
+
+```yaml
+Type: ActiveDirectorySecurityInheritance
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, All, Descendents, SelfAndChildren, Children
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InheritedObjectType
+{{ Fill InheritedObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectType
+{{ Fill ObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SID
+{{ Fill SID Description }}
+
+```yaml
+Type: String
+Parameter Sets: Sid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Self
+{{ Fill Self Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Self
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLCustom.md
+++ b/docs/Add-DSACLCustom.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLCustom
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate custom rights in target (usually an OU)
 
 ## SYNTAX
 
@@ -34,7 +34,8 @@ Add-DSACLCustom -TargetDN <String> [-Self] -ActiveDirectoryRights <ActiveDirecto
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Used to delegate any custom rights in Active Directory.
+Requires knowledge of creating ActiveDirectoryAccessRules, please use with caution.
 
 ## EXAMPLES
 
@@ -48,7 +49,7 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -AccessControlType
-{{ Fill AccessControlType Description }}
+Specifies if the Access Control Entry is Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -64,7 +65,7 @@ Accept wildcard characters: False
 ```
 
 ### -ActiveDirectoryRights
-{{ Fill ActiveDirectoryRights Description }}
+List of access rights that should be applied
 
 ```yaml
 Type: ActiveDirectoryRights[]
@@ -80,7 +81,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -95,7 +96,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritanceType
-{{ Fill InheritanceType Description }}
+Sets if and how this rule should be inherited
 
 ```yaml
 Type: ActiveDirectorySecurityInheritance
@@ -111,7 +112,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritedObjectType
-{{ Fill InheritedObjectType Description }}
+Sets guid of object types that should inherit this rule
 
 ```yaml
 Type: Guid
@@ -126,7 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectType
-{{ Fill ObjectType Description }}
+Sets guid where access right should apply
 
 ```yaml
 Type: Guid
@@ -141,7 +142,7 @@ Accept wildcard characters: False
 ```
 
 ### -SID
-{{ Fill SID Description }}
+Specify Secure Identifier (SID)
 
 ```yaml
 Type: String
@@ -156,7 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -Self
-{{ Fill Self Description }}
+Give access to "Self" instead of a user or group
 
 ```yaml
 Type: SwitchParameter
@@ -171,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLDeleteChild.md
+++ b/docs/Add-DSACLDeleteChild.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLDeleteChild
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate rights to delete objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -25,21 +25,22 @@ Add-DSACLDeleteChild -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Gu
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate rights to delete objects of selected type in target (usually an OU)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLDeleteChild -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup access to delete user objects in
+the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Specifies if the Access Control Entry is Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +56,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +71,9 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeChildren
-{{ Fill IncludeChildren Description }}
+Adds DeleteTree right allowing to delete an object and all its child objects in one operation
+
+This is often required for deleting computer objects
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +88,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -100,7 +103,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -115,7 +118,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -131,7 +134,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLDeleteChild.md
+++ b/docs/Add-DSACLDeleteChild.md
@@ -1,0 +1,160 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLDeleteChild
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLDeleteChild -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ [-AccessType <AccessControlType>] [-NoInheritance] [-IncludeChildren] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLDeleteChild -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ [-AccessType <AccessControlType>] [-NoInheritance] [-IncludeChildren] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IncludeChildren
+{{ Fill IncludeChildren Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: Computer, Contact, Group, ManagedServiceAccount, GroupManagedServiceAccount, User, All
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLFullControl.md
+++ b/docs/Add-DSACLFullControl.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLFullControl
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate FullControl rights on objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -25,21 +25,22 @@ Add-DSACLFullControl -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Gu
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate FullControl rights on objects of selected type in target (usually an OU)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> Add-DSACLFullControl -
+PS C:\> Add-DSACLFullControl -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup FullControl of user objects in
+the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance do disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Specifies if the Access Control Entry is Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +56,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +86,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +117,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLFullControl.md
+++ b/docs/Add-DSACLFullControl.md
@@ -31,7 +31,7 @@ Add-DSACLFullControl -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Gu
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLFullControl -
 ```
 
 {{ Add example description here }}

--- a/docs/Add-DSACLFullControl.md
+++ b/docs/Add-DSACLFullControl.md
@@ -1,0 +1,145 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLFullControl
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLFullControl -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLFullControl -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: Computer, Contact, Group, ManagedServiceAccount, GroupManagedServiceAccount, User, All
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLJoinDomain.md
+++ b/docs/Add-DSACLJoinDomain.md
@@ -1,0 +1,106 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLJoinDomain
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLJoinDomain [-TargetDN] <String> [-DelegateDN] <String> [-AllowCreate] [-NoInheritance]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AllowCreate
+{{ Fill AllowCreate Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLJoinDomain.md
+++ b/docs/Add-DSACLJoinDomain.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLJoinDomain
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give DelegateDN rights to join computers in target (usually an OU).
 
 ## SYNTAX
 
@@ -18,21 +18,21 @@ Add-DSACLJoinDomain [-TargetDN] <String> [-DelegateDN] <String> [-AllowCreate] [
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give DelegateDN rights to join computers in target (usually an OU).
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLJoinDomain -TargetDN $ComputersOU -DelegateDN $JoinDomainAccounts -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $JoinDomainAccounts rights to join computers to the domain. Requires a computer account to be created already.
 
 ## PARAMETERS
 
 ### -AllowCreate
-{{ Fill AllowCreate Description }}
+Allow creating computer objects, this allows to join computers without a pre-staged computer account
 
 ```yaml
 Type: SwitchParameter
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLLinkGPO.md
+++ b/docs/Add-DSACLLinkGPO.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLLinkGPO
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegate rights to link GPO on target (usually an OU)
 
 ## SYNTAX
 
@@ -18,21 +18,22 @@ Add-DSACLLinkGPO [-TargetDN] <String> [-DelegateDN] <String> [[-AccessType] <Acc
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Delegate rights to link GPO on target (usually an OU)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLLinkGPO -TargetDN $UsersOU -DelegateDN $GPAdmin -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $GPAdmin rights to link GPOs on
+the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -48,7 +49,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -63,7 +64,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -78,7 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLLinkGPO.md
+++ b/docs/Add-DSACLLinkGPO.md
@@ -1,0 +1,107 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLLinkGPO
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLLinkGPO [-TargetDN] <String> [-DelegateDN] <String> [[-AccessType] <AccessControlType>]
+ [-NoInheritance] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLManageGroupMember.md
+++ b/docs/Add-DSACLManageGroupMember.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLManageGroupMember
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate rights to manage members in group(s).
 
 ## SYNTAX
 
@@ -25,21 +25,35 @@ Add-DSACLManageGroupMember -TargetDN <String> -DelegateDN <String> [-AccessType 
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate rights to manage members in group(s).
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLManageGroupMember -TargetDN $GroupsOU -DelegateDN $AccessAdminGroup -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of any group in the OU with DistinguishedName in $GroupsOU and all sub-OUs. Add -NoInheritance do disable inheritance.
+
+### Example 2
+```powershell
+PS C:\> Add-DSACLManageGroupMember -TargetDN $GroupsOU -DelegateDN $AccessAdminGroup -AccessType Allow -NoInheritance
+```
+
+Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of any group in the OU with DistinguishedName in $GroupsOU. Will not effect groups in sub-OUs.
+
+### Example 3
+```powershell
+PS C:\> Add-DSACLManageGroupMember -TargetDN $SpecialGroup -DelegateDN $AccessAdminGroup -AccessType Allow -DirectOnGroup
+```
+
+Will give the group with DistinguishedName in $AccessAdminGroup access to manage members of the group in with DistinguishedName in $SpecialGroup.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +69,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -DirectOnGroup
-{{ Fill DirectOnGroup Description }}
+Sets access right to "This object only", use this when TargetDN is a group.
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "Children". Use this to effect all groups in OU but not subOUs
 
 ```yaml
 Type: SwitchParameter
@@ -100,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLManageGroupMember.md
+++ b/docs/Add-DSACLManageGroupMember.md
@@ -1,0 +1,129 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLManageGroupMember
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### OnContainer (Default)
+```
+Add-DSACLManageGroupMember -TargetDN <String> -DelegateDN <String> [-AccessType <AccessControlType>]
+ [-NoInheritance] [<CommonParameters>]
+```
+
+### OnGroup
+```
+Add-DSACLManageGroupMember -TargetDN <String> -DelegateDN <String> [-AccessType <AccessControlType>]
+ [-DirectOnGroup] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -DirectOnGroup
+{{ Fill DirectOnGroup Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: OnGroup
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: OnContainer
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLManagerCanUpdateGroupMember.md
+++ b/docs/Add-DSACLManagerCanUpdateGroupMember.md
@@ -8,7 +8,8 @@ schema: 2.0.0
 # Add-DSACLManagerCanUpdateGroupMember
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate rights to groups manager to manage members in group(s).
+Note that this access stays with the user if the manager changes.
 
 ## SYNTAX
 
@@ -17,21 +18,23 @@ Add-DSACLManagerCanUpdateGroupMember [-TargetDN] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate rights to groups manager to manage members in group(s).
+Note that this access stays with the user if the manager changes.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLManagerCanUpdateGroupMember -TargetDN $Group
 ```
 
-{{ Add example description here }}
+Will give the current manager of the group in $Group access to manage members.
+Note that this access stays with the user if the manager changes.
 
 ## PARAMETERS
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Has to be a group.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLManagerCanUpdateGroupMember.md
+++ b/docs/Add-DSACLManagerCanUpdateGroupMember.md
@@ -1,0 +1,60 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLManagerCanUpdateGroupMember
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLManagerCanUpdateGroupMember [-TargetDN] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLMoveObjectFrom.md
+++ b/docs/Add-DSACLMoveObjectFrom.md
@@ -1,0 +1,107 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLMoveObjectFrom
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLMoveObjectFrom [-ObjectTypeName] <String> [-TargetDN] <Object> [-DelegateDN] <Object> [-NoInheritance]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Computer, Contact, Group, ManagedServiceAccount, GroupManagedServiceAccount, User, All
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Object
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLMoveObjectFrom.md
+++ b/docs/Add-DSACLMoveObjectFrom.md
@@ -8,7 +8,8 @@ schema: 2.0.0
 # Add-DSACLMoveObjectFrom
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegates right to move object of type ObjectTypeName from TargetDN.
+Moving also requires create-child rights in target container.
 
 ## SYNTAX
 
@@ -18,7 +19,7 @@ Add-DSACLMoveObjectFrom [-ObjectTypeName] <String> [-TargetDN] <Object> [-Delega
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Delegates the rights to rename and delete objects in TargetDN.
 
 ## EXAMPLES
 
@@ -32,7 +33,7 @@ PS C:\> {{ Add example code here }}
 ## PARAMETERS
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: Object
@@ -47,7 +48,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -62,7 +63,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to allow being moved
 
 ```yaml
 Type: String
@@ -78,7 +79,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: Object

--- a/docs/Add-DSACLRenameObject.md
+++ b/docs/Add-DSACLRenameObject.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLRenameObject
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate rights to rename objects in target (usually an OU)
 
 ## SYNTAX
 
@@ -24,15 +24,15 @@ Add-DSACLRenameObject -ObjectTypeName <String> -TargetDN <String> -DelegateDN <S
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLRenameObject -ObjectTypeName Computer -TargetDN $ComputersOU -DelegateDN $ComputerAdminGroup -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $ComputerAdminGroup rights to rename computers in the OU with DistinguishedName in $ComputersOU and all sub-OUs. Add -NoInheritance do disable inheritance.
 
 ## PARAMETERS
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -47,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -62,7 +62,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to allow being renamed
 
 ```yaml
 Type: String
@@ -78,7 +78,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLRenameObject.md
+++ b/docs/Add-DSACLRenameObject.md
@@ -1,0 +1,107 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLRenameObject
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLRenameObject -ObjectTypeName <String> -TargetDN <String> -DelegateDN <String> [-NoInheritance]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Computer, Contact, Group, ManagedServiceAccount, GroupManagedServiceAccount, User, All
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLReplicatingDirectoryChanges.md
+++ b/docs/Add-DSACLReplicatingDirectoryChanges.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLReplicatingDirectoryChanges
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Give Delegate "Replicating Directory Changes" rights on domain with DistinguishedName in target
 
 ## SYNTAX
 
@@ -17,21 +17,22 @@ Add-DSACLReplicatingDirectoryChanges [-DelegateDN] <String> [-AllowReplicateSecr
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Give Delegate "Replicating Directory Changes" rights on domain with DistinguishedName in target
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLReplicatingDirectoryChanges -DelegateDN $AADCServiceAccount
 ```
 
-{{ Add example description here }}
+Will give the service account with DistinguishedName in $AADCServiceAccount the right "Replicating Directory Changes".
+Add -AllowReplicateSecrets to grant "Replicating Directory Changes All" instead..
 
 ## PARAMETERS
 
 ### -AllowReplicateSecrets
-{{ Fill AllowReplicateSecrets Description }}
+Allow replicating secrets, like passwords (Corresponds to "Replicating Directory Changes All")
 
 ```yaml
 Type: SwitchParameter
@@ -46,7 +47,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLReplicatingDirectoryChanges.md
+++ b/docs/Add-DSACLReplicatingDirectoryChanges.md
@@ -1,0 +1,75 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLReplicatingDirectoryChanges
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Add-DSACLReplicatingDirectoryChanges [-DelegateDN] <String> [-AllowReplicateSecrets] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AllowReplicateSecrets
+{{ Fill AllowReplicateSecrets Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLResetPassword.md
+++ b/docs/Add-DSACLResetPassword.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLResetPassword
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegate ResetPassword rights on objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -25,21 +25,21 @@ Add-DSACLResetPassword -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Delegate ResetPassword rights on objects of selected type in target (usually an OU)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLResetPassword -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup ResetPassword rights of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLResetPassword.md
+++ b/docs/Add-DSACLResetPassword.md
@@ -1,0 +1,145 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLResetPassword
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLResetPassword -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLResetPassword -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ [-AccessType <AccessControlType>] [-NoInheritance] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: User, Computer, ManagedServiceAccount, GroupManagedServiceAccount
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLWriteAccountRestrictions.md
+++ b/docs/Add-DSACLWriteAccountRestrictions.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLWriteAccountRestrictions
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegate rights to write to the property set "Account Restrictions" on objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -25,21 +25,21 @@ Add-DSACLWriteAccountRestrictions -TargetDN <String> -DelegateDN <String> -Objec
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Delegate rights to write to the property set "Account Restrictions" on objects of selected type in target (usually an OU)
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLWriteAccountRestrictions -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup rights to SET SPN of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+llow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String

--- a/docs/Add-DSACLWriteAccountRestrictions.md
+++ b/docs/Add-DSACLWriteAccountRestrictions.md
@@ -1,0 +1,145 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLWriteAccountRestrictions
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLWriteAccountRestrictions -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ -AccessType <AccessControlType> [-NoInheritance] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLWriteAccountRestrictions -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ -AccessType <AccessControlType> [-NoInheritance] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: User, Computer, ManagedServiceAccount, GroupManagedServiceAccount
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLWriteDNSHostName.md
+++ b/docs/Add-DSACLWriteDNSHostName.md
@@ -1,0 +1,160 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLWriteDNSHostName
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLWriteDNSHostName -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ [-AccessType <AccessControlType>] [-NoInheritance] [-ValidatedOnly] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLWriteDNSHostName -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ [-AccessType <AccessControlType>] [-NoInheritance] [-ValidatedOnly] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: Computer, ManagedServiceAccount, GroupManagedServiceAccount
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ValidatedOnly
+{{ Fill ValidatedOnly Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLWriteDNSHostName.md
+++ b/docs/Add-DSACLWriteDNSHostName.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLWriteDNSHostName
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegate rights to SET DNSHostName on objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -31,15 +31,15 @@ Add-DSACLWriteDNSHostName -TargetDN <String> -DelegateDN <String> -ObjectTypeGui
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLWriteDNSHostName -TargetDN $ComputersOU -DelegateDN $ComputerAdminGroup -ObjectTypeName Computer -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $ComputerAdminGroup rights to SET DNSHostName of computer objects in the OU with DistinguishedName in $ComputersOU and all sub-OUs. Add -NoInheritance to disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Allow or Deny. Allow is set by default
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String
@@ -131,7 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -ValidatedOnly
-{{ Fill ValidatedOnly Description }}
+Only effects validated writes
 
 ```yaml
 Type: SwitchParameter

--- a/docs/Add-DSACLWriteServicePrincipalName.md
+++ b/docs/Add-DSACLWriteServicePrincipalName.md
@@ -1,0 +1,160 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Add-DSACLWriteServicePrincipalName
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### ByTypeName (Default)
+```
+Add-DSACLWriteServicePrincipalName -TargetDN <String> -DelegateDN <String> -ObjectTypeName <String>
+ -AccessType <AccessControlType> [-NoInheritance] [-ValidatedOnly] [<CommonParameters>]
+```
+
+### ByGuid
+```
+Add-DSACLWriteServicePrincipalName -TargetDN <String> -DelegateDN <String> -ObjectTypeGuid <Guid>
+ -AccessType <AccessControlType> [-NoInheritance] [-ValidatedOnly] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessType
+{{ Fill AccessType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DelegateDN
+{{ Fill DelegateDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -NoInheritance
+{{ Fill NoInheritance Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeGuid
+{{ Fill ObjectTypeGuid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: ByGuid
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectTypeName
+{{ Fill ObjectTypeName Description }}
+
+```yaml
+Type: String
+Parameter Sets: ByTypeName
+Aliases:
+Accepted values: User, Computer, ManagedServiceAccount, GroupManagedServiceAccount
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetDN
+{{ Fill TargetDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -ValidatedOnly
+{{ Fill ValidatedOnly Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Add-DSACLWriteServicePrincipalName.md
+++ b/docs/Add-DSACLWriteServicePrincipalName.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Add-DSACLWriteServicePrincipalName
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Delegate rights to SET ServicePrincipalName (SPN) on objects of selected type in target (usually an OU)
 
 ## SYNTAX
 
@@ -31,15 +31,15 @@ Add-DSACLWriteServicePrincipalName -TargetDN <String> -DelegateDN <String> -Obje
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> Add-DSACLWriteServicePrincipalName -TargetDN $UsersOU -DelegateDN $UserAdminGroup -ObjectTypeName User -AccessType Allow
 ```
 
-{{ Add example description here }}
+Will give the group with DistinguishedName in $UserAdminGroup rights to SET SPN of user objects in the OU with DistinguishedName in $UsersOU and all sub-OUs. Add -NoInheritance to disable inheritance.
 
 ## PARAMETERS
 
 ### -AccessType
-{{ Fill AccessType Description }}
+Allow or Deny
 
 ```yaml
 Type: AccessControlType
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 ```
 
 ### -DelegateDN
-{{ Fill DelegateDN Description }}
+DistinguishedName of group or user to give permissions to.
 
 ```yaml
 Type: String
@@ -70,7 +70,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoInheritance
-{{ Fill NoInheritance Description }}
+Sets access right to "This object only"
 
 ```yaml
 Type: SwitchParameter
@@ -85,7 +85,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeGuid
-{{ Fill ObjectTypeGuid Description }}
+ObjectType guid, used for custom object types
 
 ```yaml
 Type: Guid
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectTypeName
-{{ Fill ObjectTypeName Description }}
+Object type to give full control over
 
 ```yaml
 Type: String
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -TargetDN
-{{ Fill TargetDN Description }}
+DistinguishedName of object to modify ACL on. Usually an OU.
 
 ```yaml
 Type: String
@@ -131,7 +131,7 @@ Accept wildcard characters: False
 ```
 
 ### -ValidatedOnly
-{{ Fill ValidatedOnly Description }}
+Only effects validated writes
 
 ```yaml
 Type: SwitchParameter

--- a/docs/ConvertFrom-DSACLInheritedObjectTypeGuid.md
+++ b/docs/ConvertFrom-DSACLInheritedObjectTypeGuid.md
@@ -1,0 +1,83 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-DSACLInheritedObjectTypeGuid
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### Access (Default)
+```
+ConvertFrom-DSACLInheritedObjectTypeGuid -AccessRule <ActiveDirectoryAccessRule> [<CommonParameters>]
+```
+
+### Audit
+```
+ConvertFrom-DSACLInheritedObjectTypeGuid -AuditRule <ActiveDirectoryAuditRule> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessRule
+{{ Fill AccessRule Description }}
+
+```yaml
+Type: ActiveDirectoryAccessRule
+Parameter Sets: Access
+Aliases: Access, ACE
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -AuditRule
+{{ Fill AuditRule Description }}
+
+```yaml
+Type: ActiveDirectoryAuditRule
+Parameter Sets: Audit
+Aliases: Audit
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.DirectoryServices.ActiveDirectoryAccessRule
+
+### System.DirectoryServices.ActiveDirectoryAuditRule
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/ConvertFrom-DSACLObjectTypeGuid.md
+++ b/docs/ConvertFrom-DSACLObjectTypeGuid.md
@@ -1,0 +1,83 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# ConvertFrom-DSACLObjectTypeGuid
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### Access (Default)
+```
+ConvertFrom-DSACLObjectTypeGuid -AccessRule <ActiveDirectoryAccessRule> [<CommonParameters>]
+```
+
+### Audit
+```
+ConvertFrom-DSACLObjectTypeGuid -AuditRule <ActiveDirectoryAuditRule> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessRule
+{{ Fill AccessRule Description }}
+
+```yaml
+Type: ActiveDirectoryAccessRule
+Parameter Sets: Access
+Aliases: Access, ACE
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -AuditRule
+{{ Fill AuditRule Description }}
+
+```yaml
+Type: ActiveDirectoryAuditRule
+Parameter Sets: Audit
+Aliases: Audit
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.DirectoryServices.ActiveDirectoryAccessRule
+
+### System.DirectoryServices.ActiveDirectoryAuditRule
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Get-DSACLDefaultContainer.md
+++ b/docs/Get-DSACLDefaultContainer.md
@@ -1,0 +1,76 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Get-DSACLDefaultContainer
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Get-DSACLDefaultContainer [[-DomainDN] <Object>] [[-Type] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DomainDN
+{{ Fill DomainDN Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+{{ Fill Type Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Users, Computers
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Get-DSACLMachineAccountQuota.md
+++ b/docs/Get-DSACLMachineAccountQuota.md
@@ -1,0 +1,45 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Get-DSACLMachineAccountQuota
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Get-DSACLMachineAccountQuota [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-DSACLAccessRule.md
+++ b/docs/New-DSACLAccessRule.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-DSACLAccessRule
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Create Access Control Entry for Active Directory ACL
 
 ## SYNTAX
 
@@ -53,21 +53,21 @@ New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <Activ
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Create Access Control Entry for Active Directory ACL
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> New-ADAccessRule -Identity $SID -ActiveDirectoryRights 'CreateChild', 'DeleteChild' -AccessControlType Allow -ObjectType $TypeGuid -InheritanceType None
 ```
 
-{{ Add example description here }}
+Create access rule that gives the object with SID $SID access to create and delete objects of type $TypeGuid on "this object only"
 
 ## PARAMETERS
 
 ### -AccessControlType
-{{ Fill AccessControlType Description }}
+Sets allow or deny
 
 ```yaml
 Type: AccessControlType
@@ -83,7 +83,7 @@ Accept wildcard characters: False
 ```
 
 ### -ActiveDirectoryRights
-{{ Fill ActiveDirectoryRights Description }}
+List of access rights that should be applied
 
 ```yaml
 Type: ActiveDirectoryRights[]
@@ -99,7 +99,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+SID of principal that will rule will apply to
 
 ```yaml
 Type: SecurityIdentifier
@@ -114,7 +114,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritanceType
-{{ Fill InheritanceType Description }}
+Sets if and how this rule should be inherited
 
 ```yaml
 Type: ActiveDirectorySecurityInheritance
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritedObjectType
-{{ Fill InheritedObjectType Description }}
+Sets guid of object types that should inherit this rule
 
 ```yaml
 Type: Guid
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectType
-{{ Fill ObjectType Description }}
+Sets guid where access right should apply
 
 ```yaml
 Type: Guid

--- a/docs/New-DSACLAccessRule.md
+++ b/docs/New-DSACLAccessRule.md
@@ -1,0 +1,182 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# New-DSACLAccessRule
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### 6
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> -ObjectType <Guid>
+ -InheritanceType <ActiveDirectorySecurityInheritance> -InheritedObjectType <Guid> [<CommonParameters>]
+```
+
+### 5
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> -ObjectType <Guid>
+ -InheritanceType <ActiveDirectorySecurityInheritance> [<CommonParameters>]
+```
+
+### 4
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> -ObjectType <Guid> [<CommonParameters>]
+```
+
+### 3
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> -InheritanceType <ActiveDirectorySecurityInheritance>
+ -InheritedObjectType <Guid> [<CommonParameters>]
+```
+
+### 2
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> -InheritanceType <ActiveDirectorySecurityInheritance>
+ [<CommonParameters>]
+```
+
+### 1
+```
+New-DSACLAccessRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AccessControlType <AccessControlType> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -AccessControlType
+{{ Fill AccessControlType Description }}
+
+```yaml
+Type: AccessControlType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ActiveDirectoryRights
+{{ Fill ActiveDirectoryRights Description }}
+
+```yaml
+Type: ActiveDirectoryRights[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: CreateChild, DeleteChild, ListChildren, Self, ReadProperty, WriteProperty, DeleteTree, ListObject, ExtendedRight, Delete, ReadControl, GenericExecute, GenericWrite, GenericRead, WriteDacl, WriteOwner, GenericAll, Synchronize, AccessSystemSecurity
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -InheritanceType
+{{ Fill InheritanceType Description }}
+
+```yaml
+Type: ActiveDirectorySecurityInheritance
+Parameter Sets: 6, 5, 3, 2
+Aliases:
+Accepted values: None, All, Descendents, SelfAndChildren, Children
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -InheritedObjectType
+{{ Fill InheritedObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: 6, 3
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectType
+{{ Fill ObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: 6, 5, 4
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.DirectoryServices.ActiveDirectoryRights[]
+
+### System.Security.AccessControl.AccessControlType
+
+### System.Guid
+
+### System.DirectoryServices.ActiveDirectorySecurityInheritance
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-DSACLAuditRule.md
+++ b/docs/New-DSACLAuditRule.md
@@ -1,0 +1,181 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# New-DSACLAuditRule
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+### 6
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> -ObjectType <Guid> -InheritanceType <ActiveDirectorySecurityInheritance>
+ -InheritedObjectType <Guid> [<CommonParameters>]
+```
+
+### 5
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> -ObjectType <Guid> -InheritanceType <ActiveDirectorySecurityInheritance>
+ [<CommonParameters>]
+```
+
+### 4
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> -ObjectType <Guid> [<CommonParameters>]
+```
+
+### 3
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> -InheritanceType <ActiveDirectorySecurityInheritance> -InheritedObjectType <Guid>
+ [<CommonParameters>]
+```
+
+### 2
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> -InheritanceType <ActiveDirectorySecurityInheritance> [<CommonParameters>]
+```
+
+### 1
+```
+New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <ActiveDirectoryRights[]>
+ -AuditFlags <AuditFlags> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -ActiveDirectoryRights
+{{ Fill ActiveDirectoryRights Description }}
+
+```yaml
+Type: ActiveDirectoryRights[]
+Parameter Sets: (All)
+Aliases:
+Accepted values: CreateChild, DeleteChild, ListChildren, Self, ReadProperty, WriteProperty, DeleteTree, ListObject, ExtendedRight, Delete, ReadControl, GenericExecute, GenericWrite, GenericRead, WriteDacl, WriteOwner, GenericAll, Synchronize, AccessSystemSecurity
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -AuditFlags
+{{ Fill AuditFlags Description }}
+
+```yaml
+Type: AuditFlags
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Success, Failure
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Identity
+{{ Fill Identity Description }}
+
+```yaml
+Type: SecurityIdentifier
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -InheritanceType
+{{ Fill InheritanceType Description }}
+
+```yaml
+Type: ActiveDirectorySecurityInheritance
+Parameter Sets: 6, 5, 3, 2
+Aliases:
+Accepted values: None, All, Descendents, SelfAndChildren, Children
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -InheritedObjectType
+{{ Fill InheritedObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: 6, 3
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -ObjectType
+{{ Fill ObjectType Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: 6, 5, 4
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Security.Principal.SecurityIdentifier
+
+### System.DirectoryServices.ActiveDirectoryRights[]
+
+### System.Security.AccessControl.AuditFlags
+
+### System.Guid
+
+### System.DirectoryServices.ActiveDirectorySecurityInheritance
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/New-DSACLAuditRule.md
+++ b/docs/New-DSACLAuditRule.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # New-DSACLAuditRule
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Create Access Control Entry for Active Directory ACL
 
 ## SYNTAX
 
@@ -52,21 +52,21 @@ New-DSACLAuditRule -Identity <SecurityIdentifier> -ActiveDirectoryRights <Active
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Create Access Control Entry for Active Directory ACL
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+PS C:\> New-ADAccessRule -Identity $SID -ActiveDirectoryRights 'CreateChild', 'DeleteChild' -AccessControlType Allow -ObjectType $TypeGuid -InheritanceType None
 ```
 
-{{ Add example description here }}
+Create access rule that gives the object with SID $SID access to create and delete objects of type $TypeGuid on "this object only"
 
 ## PARAMETERS
 
 ### -ActiveDirectoryRights
-{{ Fill ActiveDirectoryRights Description }}
+List of access rights that should be applied
 
 ```yaml
 Type: ActiveDirectoryRights[]
@@ -82,7 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -AuditFlags
-{{ Fill AuditFlags Description }}
+Sets allow or deny
 
 ```yaml
 Type: AuditFlags
@@ -98,7 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -Identity
-{{ Fill Identity Description }}
+SID of principal that will rule will apply to
 
 ```yaml
 Type: SecurityIdentifier
@@ -113,7 +113,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritanceType
-{{ Fill InheritanceType Description }}
+Sets if and how this rule should be inherited
 
 ```yaml
 Type: ActiveDirectorySecurityInheritance
@@ -129,7 +129,7 @@ Accept wildcard characters: False
 ```
 
 ### -InheritedObjectType
-{{ Fill InheritedObjectType Description }}
+Sets guid of object types that should inherit this rule
 
 ```yaml
 Type: Guid
@@ -144,7 +144,7 @@ Accept wildcard characters: False
 ```
 
 ### -ObjectType
-{{ Fill ObjectType Description }}
+Sets guid where access right should apply
 
 ```yaml
 Type: Guid

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# DSACL - Documentation
+
+DSACL documentation is made possible using [platyPS](https://github.com/PowerShell/platyPS)
+
+## Contributions to DSACL documentation
+
+1. Fork the repository
+2. Checkout a new branch
+3. Install platyPS and DSACL:
+
+```powershell
+Install-Module PlatyPS -Force -Verbose
+Install-Module DSACL -Force -Verbose
+```
+
+4. Edit the markdown files in /docs
+5. Update external help
+6. Push changes

--- a/docs/Register-DSACLRightsMapVariable.md
+++ b/docs/Register-DSACLRightsMapVariable.md
@@ -1,0 +1,60 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Register-DSACLRightsMapVariable
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Register-DSACLRightsMapVariable [[-Scope] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Scope
+{{ Fill Scope Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Resolve-DSACLGuid.md
+++ b/docs/Resolve-DSACLGuid.md
@@ -1,0 +1,60 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Resolve-DSACLGuid
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Resolve-DSACLGuid [[-Guid] <Guid>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Guid
+{{ Fill Guid Description }}
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Resolve-DSACLObjectName.md
+++ b/docs/Resolve-DSACLObjectName.md
@@ -1,0 +1,60 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Resolve-DSACLObjectName
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Resolve-DSACLObjectName [[-Name] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Name
+{{ Fill Name Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Set-DSACLDefaultContainer.md
+++ b/docs/Set-DSACLDefaultContainer.md
@@ -1,0 +1,91 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Set-DSACLDefaultContainer
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Set-DSACLDefaultContainer [[-DomainDN] <String>] [[-Type] <String>] [[-NewValue] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -DomainDN
+{{ Fill DomainDN Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewValue
+{{ Fill NewValue Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+{{ Fill Type Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Users, Computers
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Set-DSACLMachineAccountQuota.md
+++ b/docs/Set-DSACLMachineAccountQuota.md
@@ -1,0 +1,60 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Set-DSACLMachineAccountQuota
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Set-DSACLMachineAccountQuota [-Quota] <Int32> [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Quota
+{{ Fill Quota Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/docs/Set-DSACLOwner.md
+++ b/docs/Set-DSACLOwner.md
@@ -1,0 +1,110 @@
+---
+external help file: DSACL-help.xml
+Module Name: DSACL
+online version:
+schema: 2.0.0
+---
+
+# Set-DSACLOwner
+
+## SYNOPSIS
+Sets an Active Directory object as the Owner of an Access Control List (ACL).
+
+## SYNTAX
+
+```
+Set-DSACLOwner [-TargetDN] <String> [-OwnerDN] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The **Set-DSACLOwner** cmdlet will set the given OwnerDN (Objects Distinguished Name) as Owner of the specified TargetDN (Target Distinguished Name).
+
+The TargetDN parameter specifies what object the modification will execute on.
+
+The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-DSACLOwner -TargetDN "OU=Accounting,DC=FABRIKAM,DC=COM" -OwnerDN "CN=Chew David,OU=Accounting,DC=FABRIKAM,DC=COM"
+```
+
+The following example will set Chew David as owner of the Accounting Organizational Units Access Control List.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OwnerDN
+The OwnerDN parameter specifies what object in Active Directory that will take ownership of the target.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -TargetDN
+The TargetDN parameter specifies what object the modification will execute on.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
Hey @SimonWahlin !

I was wondering if you would like to re-do how this module manages its help files.
I would be up for creating something like this PR hints at, help using PlatyPS in markdown format and add the us-EN\xml file for the module. This way it's easier to view the help content online (using github) and we could make more slight changes without having to edit the actual functions.

I would be up to making sure all the help files are up to date (this PR includes only a manual edit of Set-DSACLOwner), but I would plan to create help files for the rest of the (awesome) functions similarly.

You can just remove this PR if you do not want this or get back to me with how you would want it (this is just an idea).

Would be awesome because I think this module really serves a great purpose and fills a huge gap in AD ACL management.

Best regards!
Emil